### PR TITLE
Fix typo in "too full" message

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -419,7 +419,7 @@ MACRO_CONFIG_STR(TrNoPermission, tr_no_permission, 512, "You don't have permissi
 MACRO_CONFIG_STR(TrTooMany, tr_too_many, 256, "You have made too many captures, please cancel some of them before capturing more.", CFGFLAG_SERVER, "")
 MACRO_CONFIG_STR(TrFrozen, tr_frozen, 256, "You can't capture when frozen.", CFGFLAG_SERVER, "")
 MACRO_CONFIG_STR(TrOutOfBounds, tr_out_of_bounds, 256, "You can't capture out of bounds.", CFGFLAG_SERVER, "")
-MACRO_CONFIG_STR(TrTooFull, tr_too_full, 256, "This area is too crowed, please capture at another place.", CFGFLAG_SERVER, "")
+MACRO_CONFIG_STR(TrTooFull, tr_too_full, 256, "This area is too crowded, please capture at another place.", CFGFLAG_SERVER, "")
 MACRO_CONFIG_STR(TrTooClose, tr_too_close, 256, "You are too close to other tees, please capture at another place.", CFGFLAG_SERVER, "")
 
 MACRO_CONFIG_INT(SvYear, sv_year, 2025, 1, 9999, CFGFLAG_SERVER, "Year of the event (show in score)")


### PR DESCRIPTION
I think that it is supposed to say "crowded", not "crowed".